### PR TITLE
Don't create redundant redirects & autoremove 

### DIFF
--- a/EpiserverRedirects/EpiserverRedirects.csproj
+++ b/EpiserverRedirects/EpiserverRedirects.csproj
@@ -61,10 +61,12 @@
     <Compile Include="UrlRewritePlugin\Menu\UrlRedirectsMenuStore.cs" />
     <Compile Include="UrlRewritePlugin\Menu\UrlRedirectsMenuView.cs" />
     <Compile Include="UrlRewritePlugin\RedirectHelper.cs" />
+    <Compile Include="UrlRewritePlugin\RedirectStatusCode.cs" />
     <Compile Include="UrlRewritePlugin\StringExtensions.cs" />
     <Compile Include="UrlRewritePlugin\UrlRedirectsDto.cs" />
     <Compile Include="UrlRewritePlugin\UrlRedirectsModelMapper.cs" />
     <Compile Include="UrlRewritePlugin\UrlRedirectsService.cs" />
+    <Compile Include="UrlRewritePlugin\UrlRedirectsType.cs" />
     <Compile Include="UrlRewritePlugin\UrlRewriteMiddleware.cs" />
     <Compile Include="UrlRewritePlugin\UrlRewriteModel.cs" />
     <Compile Include="UrlRewritePlugin\UrlRewriteModule.cs" />

--- a/EpiserverRedirects/UrlRewritePlugin/Menu/UrlRedirectsMenuStore.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/Menu/UrlRedirectsMenuStore.cs
@@ -69,7 +69,7 @@ namespace Forte.EpiserverRedirects.UrlRewritePlugin.Menu
                 .OrderBy(sortColumns)
                 .ApplyRange(range)
                 .Items.AsEnumerable()
-                .Select(item => item.MapToUrlRedirectsDtoModel());
+                .Select(item => item.MapToUrlRedirectsDto());
 
             HttpContext.Response.Headers.Add("Content-Range", $"0/{urlRewriteStore.Count()}");
             return Rest(results);

--- a/EpiserverRedirects/UrlRewritePlugin/RedirectHelper.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/RedirectHelper.cs
@@ -79,9 +79,10 @@ namespace Forte.EpiserverRedirects.UrlRewritePlugin
         {
             var urlRedirectsService = ServiceLocator.Current.GetInstance<IUrlRedirectsService>();
 
+            var deletedDescendantsIds = deletedDescendants.Select(x => x.ID).ToList();
+            
             var redirectsToDelete = urlRedirectsService.GetAll()
-                .ToList()
-                .Where(x => deletedContent.ID == x.ContentId || deletedDescendants.Contains(new ContentReference(x.ContentId)))
+                .Where(x => deletedContent.ID == x.ContentId || deletedDescendantsIds.Contains(x.ContentId))
                 .Select(x => x.Id.ExternalId)
                 .ToList();
 

--- a/EpiserverRedirects/UrlRewritePlugin/RedirectHelper.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/RedirectHelper.cs
@@ -23,7 +23,7 @@ namespace Forte.EpiserverRedirects.UrlRewritePlugin
             var urlRewriteModels = urlRedirectsService.GetAll();
             var urlRewriteModel = urlRewriteModels.GetRedirectModel(oldUrl) ?? urlRewriteModels.GetManualWildcardTypeRedirectModel(oldUrl);
 
-            return urlRewriteModel?.MapToUrlRedirectsDtoModel();
+            return urlRewriteModel?.MapToUrlRedirectsDto();
         }
 
         private static UrlRewriteModel GetRedirectModel(this IQueryable<UrlRewriteModel> urlRewriteStore, string oldUrl)
@@ -57,21 +57,16 @@ namespace Forte.EpiserverRedirects.UrlRewritePlugin
         private static void AddRedirectsToDDS(PageData pageData, string oldUrl)
         {
             if (!(pageData.Status == VersionStatus.PreviouslyPublished || pageData.Status == VersionStatus.Published)) return;
-            
-            var urlRedirectsDto = new UrlRedirectsDto
-            {
-                OldUrl = oldUrl.NormalizePath(),
-                ContentId = pageData.ContentLink.ID,
-                Type = UrlRedirectsType.System,
-                Priority = 1,
-                RedirectStatusCode = RedirectStatusCode.Permanent
-            };
+
+            var urlRedirectsDto = new UrlRedirectsDto(
+                oldUrl.NormalizePath(), pageData.ContentLink.ID, UrlRedirectsType.System, 1,
+                RedirectStatusCode.Permanent);
 
             var urlRedirectsService = ServiceLocator.Current.GetInstance<IUrlRedirectsService>();
 
             try
             {
-                urlRedirectsService.Post(urlRedirectsDto);
+                urlRedirectsService.Put(urlRedirectsDto);
             }
             catch (ApplicationException)
             {

--- a/EpiserverRedirects/UrlRewritePlugin/RedirectHelper.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/RedirectHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -71,6 +72,22 @@ namespace Forte.EpiserverRedirects.UrlRewritePlugin
             catch (ApplicationException)
             {
                 return;
+            }
+        }
+        
+        public static void DeleteRedirects(ContentReference deletedContent, IEnumerable<ContentReference> deletedDescendants)
+        {
+            var urlRedirectsService = ServiceLocator.Current.GetInstance<IUrlRedirectsService>();
+
+            var redirectsToDelete = urlRedirectsService.GetAll()
+                .ToList()
+                .Where(x => deletedContent.ID == x.ContentId || deletedDescendants.Contains(new ContentReference(x.ContentId)))
+                .Select(x => x.Id.ExternalId)
+                .ToList();
+
+            foreach (var redirect in redirectsToDelete)
+            {
+                urlRedirectsService.Delete(redirect);
             }
         }
 

--- a/EpiserverRedirects/UrlRewritePlugin/RedirectStatusCode.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/RedirectStatusCode.cs
@@ -1,0 +1,8 @@
+﻿namespace Forte.EpiserverRedirects.UrlRewritePlugin
+{
+    public enum RedirectStatusCode
+    {
+        Permanent = 301,
+        Temporary = 302
+    }
+}

--- a/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsDto.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsDto.cs
@@ -19,19 +19,48 @@ namespace Forte.EpiserverRedirects.UrlRewritePlugin
 
     public class UrlRedirectsDto
     {
-        public Guid Id { get; set; }
+        public Guid Id { get; }
 
-        public string OldUrl { get; set; }
+        public string OldUrl { get; }
 
-        public string NewUrl { get; set; }
+        public string NewUrl { get; }
 
-        public int ContentId { get; set; }
+        public int ContentId { get; }
 
         [JsonConverter(typeof(StringEnumConverter))]
-        public UrlRedirectsType Type { get; set; }
+        public UrlRedirectsType Type { get; }
 
-        public int Priority { get; set; }
+        public int Priority { get; }
 
-        public RedirectStatusCode RedirectStatusCode { get; set; }
+        public RedirectStatusCode RedirectStatusCode { get; }
+
+        internal UrlRedirectsDto(Guid id, string oldUrl, string newUrl, int contentId, UrlRedirectsType type, int priority, RedirectStatusCode redirectStatusCode)
+        {
+            Id = id;
+            OldUrl = oldUrl;
+            NewUrl = newUrl;
+            ContentId = contentId;
+            Type = type;
+            Priority = priority;
+            RedirectStatusCode = redirectStatusCode;
+        }
+
+        public UrlRedirectsDto(string oldUrl, int contentId, UrlRedirectsType type, int priority, RedirectStatusCode redirectStatusCode)
+        {
+            OldUrl = oldUrl;
+            ContentId = contentId;
+            Type = type;
+            Priority = priority;
+            RedirectStatusCode = redirectStatusCode;
+        }
+        
+        public UrlRedirectsDto(string oldUrl, string newUrl, UrlRedirectsType type, int priority, RedirectStatusCode redirectStatusCode)
+        {
+            OldUrl = oldUrl;
+            NewUrl = newUrl;
+            Type = type;
+            Priority = priority;
+            RedirectStatusCode = redirectStatusCode;
+        }
     }
 }

--- a/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsDto.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsDto.cs
@@ -4,36 +4,23 @@ using Newtonsoft.Json.Converters;
 
 namespace Forte.EpiserverRedirects.UrlRewritePlugin
 {
-    public enum UrlRedirectsType
-    {
-        System,
-        Manual,
-        ManualWildcard
-    }
-
-    public enum RedirectStatusCode
-    {
-        Permanent = 301,
-        Temporary = 302
-    }
-
     public class UrlRedirectsDto
     {
         public Guid Id { get; }
-
         public string OldUrl { get; }
-
         public string NewUrl { get; }
-
         public int ContentId { get; }
 
         [JsonConverter(typeof(StringEnumConverter))]
         public UrlRedirectsType Type { get; }
 
         public int Priority { get; }
-
         public RedirectStatusCode RedirectStatusCode { get; }
 
+        /// <summary>
+        /// Meant to be used ONLY when mapping from redirect model. When adding redirects, other ctors should be used
+        /// (not providing the id) 
+        /// </summary>
         internal UrlRedirectsDto(Guid id, string oldUrl, string newUrl, int contentId, UrlRedirectsType type, int priority, RedirectStatusCode redirectStatusCode)
         {
             Id = id;

--- a/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsDto.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsDto.cs
@@ -6,22 +6,12 @@ namespace Forte.EpiserverRedirects.UrlRewritePlugin
 {
     public class UrlRedirectsDto
     {
-        public Guid Id { get; }
-        public string OldUrl { get; }
-        public string NewUrl { get; }
-        public int ContentId { get; }
-
-        [JsonConverter(typeof(StringEnumConverter))]
-        public UrlRedirectsType Type { get; }
-
-        public int Priority { get; }
-        public RedirectStatusCode RedirectStatusCode { get; }
-
         /// <summary>
-        /// Meant to be used ONLY when mapping from redirect model. When adding redirects, other ctors should be used
-        /// (not providing the id) 
+        ///     Meant to be used ONLY when mapping from redirect model. When adding redirects, other ctors should be used
+        ///     (not providing the id)
         /// </summary>
-        internal UrlRedirectsDto(Guid id, string oldUrl, string newUrl, int contentId, UrlRedirectsType type, int priority, RedirectStatusCode redirectStatusCode)
+        internal UrlRedirectsDto(Guid id, string oldUrl, string newUrl, int contentId, UrlRedirectsType type,
+            int priority, RedirectStatusCode redirectStatusCode)
         {
             Id = id;
             OldUrl = oldUrl;
@@ -32,22 +22,27 @@ namespace Forte.EpiserverRedirects.UrlRewritePlugin
             RedirectStatusCode = redirectStatusCode;
         }
 
-        public UrlRedirectsDto(string oldUrl, int contentId, UrlRedirectsType type, int priority, RedirectStatusCode redirectStatusCode)
+        public UrlRedirectsDto(string oldUrl, int contentId, UrlRedirectsType type, int priority,
+            RedirectStatusCode redirectStatusCode) : this(Guid.Empty, oldUrl, null, contentId, type, priority,
+            redirectStatusCode)
         {
-            OldUrl = oldUrl;
-            ContentId = contentId;
-            Type = type;
-            Priority = priority;
-            RedirectStatusCode = redirectStatusCode;
         }
-        
-        public UrlRedirectsDto(string oldUrl, string newUrl, UrlRedirectsType type, int priority, RedirectStatusCode redirectStatusCode)
+
+        public UrlRedirectsDto(string oldUrl, string newUrl, UrlRedirectsType type, int priority,
+            RedirectStatusCode redirectStatusCode) : this(Guid.Empty, oldUrl, newUrl, 0, type, priority,
+            redirectStatusCode)
         {
-            OldUrl = oldUrl;
-            NewUrl = newUrl;
-            Type = type;
-            Priority = priority;
-            RedirectStatusCode = redirectStatusCode;
         }
+
+        public Guid Id { get; }
+        public string OldUrl { get; }
+        public string NewUrl { get; }
+        public int ContentId { get; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public UrlRedirectsType Type { get; }
+
+        public int Priority { get; }
+        public RedirectStatusCode RedirectStatusCode { get; }
     }
 }

--- a/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsModelMapper.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsModelMapper.cs
@@ -2,27 +2,22 @@
 
 namespace Forte.EpiserverRedirects.UrlRewritePlugin
 {
-    public static class UrlRedirectsModelMapper
+    internal static class UrlRedirectsModelMapper
     {
-        public static UrlRedirectsDto MapToUrlRedirectsDtoModel(this UrlRewriteModel urlRewriteModel)
+        public static UrlRedirectsDto MapToUrlRedirectsDto(this UrlRewriteModel urlRewriteModel)
         {
             if(!Enum.TryParse(urlRewriteModel.Type, out UrlRedirectsType urlRedirectsType)) { throw new ArgumentException("Invalid UrlRedirects Type"); }
 
-            return new UrlRedirectsDto()
-            {
-                Id = urlRewriteModel.Id.ExternalId,
-                OldUrl = urlRewriteModel.OldUrl,
-                NewUrl = urlRewriteModel.NewUrl ?? RedirectHelper.GetRedirectUrl(urlRewriteModel.ContentId),
-                ContentId = urlRewriteModel.ContentId,
-                Type = urlRedirectsType,
-                Priority = urlRewriteModel.Priority,
-                RedirectStatusCode = (RedirectStatusCode)urlRewriteModel.RedirectStatusCode
-            };
+            return new UrlRedirectsDto(
+                urlRewriteModel.Id.ExternalId, urlRewriteModel.OldUrl,
+                urlRewriteModel.NewUrl ?? RedirectHelper.GetRedirectUrl(urlRewriteModel.ContentId),
+                urlRewriteModel.ContentId, urlRedirectsType, urlRewriteModel.Priority,
+                (RedirectStatusCode) urlRewriteModel.RedirectStatusCode);
         }
 
         public static UrlRewriteModel MapToUrlRewriteModel(this UrlRedirectsDto urlRedirectsDtoModel)
         {
-            var urlRewriteModel = new UrlRewriteModel()
+            var urlRewriteModel = new UrlRewriteModel
             {
                 OldUrl = urlRedirectsDtoModel.OldUrl,
                 NewUrl = urlRedirectsDtoModel.NewUrl,

--- a/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsService.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsService.cs
@@ -46,7 +46,7 @@ namespace Forte.EpiserverRedirects.UrlRewritePlugin
 
             urlRewriteModel.Id = identity;
 
-            return urlRewriteModel.MapToUrlRedirectsDtoModel();
+            return urlRewriteModel.MapToUrlRedirectsDto();
         }
 
         public UrlRedirectsDto Put(UrlRedirectsDto urlRedirectsDto)
@@ -54,17 +54,13 @@ namespace Forte.EpiserverRedirects.UrlRewritePlugin
             var store = dynamicDataStoreFactory.CreateStore(typeof(UrlRewriteModel));
             var urlRewriteModel = urlRedirectsDto.MapToUrlRewriteModel();
 
-            var redirectAlreadyExist = store.Items<UrlRewriteModel>()
-                .FirstOrDefault(x => x.OldUrl == urlRewriteModel.OldUrl && x.Id.ExternalId != urlRedirectsDto.Id);
+            var existingRedirect = store.Items<UrlRewriteModel>()
+                .FirstOrDefault(x => x.OldUrl == urlRewriteModel.OldUrl);
 
-            if (redirectAlreadyExist != null)
-            {
-                throw new ApplicationException($"Redirect with this oldUrl: {urlRedirectsDto.OldUrl} already exist");
-            }
-
-            store.Save(urlRewriteModel, urlRedirectsDto.Id);
-
-            return urlRewriteModel.MapToUrlRedirectsDtoModel();
+            var newIdentity = store.Save(urlRewriteModel, existingRedirect?.Id);
+            urlRewriteModel.Id = newIdentity.ExternalId;
+            
+            return urlRewriteModel.MapToUrlRedirectsDto();
         }
     }
 }

--- a/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsType.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsType.cs
@@ -1,0 +1,9 @@
+﻿namespace Forte.EpiserverRedirects.UrlRewritePlugin
+{
+    public enum UrlRedirectsType
+    {
+        System,
+        Manual,
+        ManualWildcard
+    }
+}

--- a/EpiserverRedirects/UrlRewritePlugin/UrlRewriteMiddleware.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/UrlRewriteMiddleware.cs
@@ -35,7 +35,6 @@ namespace Forte.EpiserverRedirects.UrlRewritePlugin
                     context.Response.Headers.Set("Location", redirectUrl);
                 }
             }
-
         }
 
         private static bool IsContentDeleted(int contentId)

--- a/EpiserverRedirects/UrlRewritePlugin/UrlRewriteModule.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/UrlRewriteModule.cs
@@ -94,6 +94,14 @@ namespace Forte.EpiserverRedirects.UrlRewritePlugin
             if (!(e.Content is IChangeTrackable)) return;
 
             var originalParent = (e as MoveContentEventArgs)?.OriginalParent;
+            var targetParent = e.TargetLink;
+
+            if (originalParent == ContentReference.WasteBasket)
+            {
+                // do not create when restoring, cause not need to do redirects from waste basket.
+                // however, DO redirect when moving to waste basket, because restore may be to another place 
+                return;
+            }
             
             foreach (var language in LanguageBranchRepository.Service.ListEnabled())
             {

--- a/EpiserverRedirects/UrlRewritePlugin/UrlRewriteModule.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/UrlRewriteModule.cs
@@ -132,19 +132,21 @@ namespace Forte.EpiserverRedirects.UrlRewritePlugin
                 return;
             
             var oldUrl = e.Items[_oldUrlKey]?.ToString();
-            if (oldUrl != null)
+            if (oldUrl == null)
             {
-                var newUrl = UrlResolver.Service.GetUrl(e.ContentLink);
-
-                if(newUrl != oldUrl)
-                {
-                    var pageData = ContentRepository.Service.Get<IContentData>(e.ContentLink) as PageData;
-
-                    RedirectHelper.AddRedirects(pageData, oldUrl, GetCultureInfo(e));
-                }
-
-                e.Items.Remove(_oldUrlKey);
+                return;
             }
+            
+            var newUrl = UrlResolver.Service.GetUrl(e.ContentLink);
+
+            if(newUrl != oldUrl)
+            {
+                var pageData = ContentRepository.Service.Get<IContentData>(e.ContentLink) as PageData;
+
+                RedirectHelper.AddRedirects(pageData, oldUrl, GetCultureInfo(e));
+            }
+
+            e.Items.Remove(_oldUrlKey);
         }
 
         private static CultureInfo GetCultureInfo(ContentEventArgs e)


### PR DESCRIPTION
This pull request address following issues:
- On page publish there is no check if the page URL has changed. This results that every page publish creates a redirect to the page and all its descendants - even if old and new URL are the same. This caused publishing of page with a lot of descendants takes enormous time.
- For UrlRedirectsService, Put method was not really idempotent, but failing when trying to create a redirect to already existing URL. I've changed this in the following way:
    - Remove all DTO setters. DTO now may be initialized only by ctor parameters.
    - Constructor with id was made internal and should be used only when returning results from the service. When creating redirects, use one of other two constructors (providing either content link or new URL).
    - Make Put method idempotent, which mean that calling it twice with the same parameters have the same effect as running once and does not throw errors anymore
- When page deleting, delete also redirects to deleted pages.
