### PR TITLE
Add UrlRedirectsDtoModelBinder to fix adding redirects via UI

### DIFF
--- a/EpiserverRedirects/EpiserverRedirects.csproj
+++ b/EpiserverRedirects/EpiserverRedirects.csproj
@@ -64,6 +64,7 @@
     <Compile Include="UrlRewritePlugin\RedirectStatusCode.cs" />
     <Compile Include="UrlRewritePlugin\StringExtensions.cs" />
     <Compile Include="UrlRewritePlugin\UrlRedirectsDto.cs" />
+    <Compile Include="UrlRewritePlugin\UrlRedirectsDtoModelBinder.cs" />
     <Compile Include="UrlRewritePlugin\UrlRedirectsModelMapper.cs" />
     <Compile Include="UrlRewritePlugin\UrlRedirectsService.cs" />
     <Compile Include="UrlRewritePlugin\UrlRedirectsType.cs" />

--- a/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsDto.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsDto.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Web.Mvc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 namespace Forte.EpiserverRedirects.UrlRewritePlugin
 {
+    [ModelBinder(typeof(UrlRedirectsDtoModelBinder))]
     public class UrlRedirectsDto
     {
         /// <summary>

--- a/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsDtoModelBinder.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/UrlRedirectsDtoModelBinder.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Web;
+using System.Web.Mvc;
+using Newtonsoft.Json;
+
+namespace Forte.EpiserverRedirects.UrlRewritePlugin
+{
+    public class UrlRedirectsDtoModelBinder : IModelBinder
+    {
+        public object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
+        {
+            var json = GetBody(controllerContext.HttpContext.Request);
+            var dto = JsonConvert.DeserializeObject<Dictionary<string,string>>(json);
+
+            try
+            {
+                return new UrlRedirectsDto(
+                    dto["oldUrl"], 
+                    dto["newUrl"], 
+                    ParseType(dto["type"]),
+                    ParsePriority(dto["priority"]), 
+                    ParseRedirectStatusCode(dto["redirectStatusCode"]));
+            }
+            catch
+            {
+                throw new Exception("Failed to parse json " + json);
+            }
+        }
+
+        private static string GetBody(HttpRequestBase request)
+        {
+            var inputStream = request.InputStream;
+            inputStream.Position = 0;
+
+            using (var reader = new StreamReader(inputStream))
+            {
+                var body = reader.ReadToEnd();
+                return body;
+            }
+        }
+
+        private RedirectStatusCode ParseRedirectStatusCode(string val)
+        {
+            Enum.TryParse<RedirectStatusCode>(val, out var code);
+            return code;
+        }
+
+        private int ParsePriority(string val)
+        {
+            return int.Parse(val);
+        }
+
+        private UrlRedirectsType ParseType(string val)
+        {
+            Enum.TryParse<UrlRedirectsType>(val, out var type);
+            return type;
+        }
+    }
+}


### PR DESCRIPTION
Making UrlRedirectsDto immutable caused that managing
redirects via user interface was not working, because it was not
able to deserialize it properly directly from HTTP body requests.
Custom model binder resolves that problem without need to have
mutable models.