### PR TITLE
Fixes moved content event handler when page has multiple language branches

### DIFF
--- a/EpiserverRedirects/UrlRewritePlugin/UrlRewriteModule.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/UrlRewriteModule.cs
@@ -107,7 +107,7 @@ namespace Forte.EpiserverRedirects.UrlRewritePlugin
             
             foreach (var language in LanguageBranchRepository.Service.ListEnabled())
             {
-                if (!(ContentRepository.Service.Get<IContentData>(e.ContentLink, language.Culture) is PageData pageData)) return;
+                if (!(ContentRepository.Service.Get<IContentData>(e.ContentLink, language.Culture) is PageData pageData)) continue;
 
                 var oldUrl = GetContentUrl(originalParent, language.Culture.Name);
                 if (oldUrl == null)


### PR DESCRIPTION
Moved content event handler does not work properly when Episerver has multiple languages enabled and moved content has only one branch. Foreach loop is terminated if page does not have language branch. It should continue not existing language branch and check other languages.