### PR TITLE
Fixes old url generation - relative urls

### DIFF
--- a/EpiserverRedirects/UrlRewritePlugin/UrlRewriteModule.cs
+++ b/EpiserverRedirects/UrlRewritePlugin/UrlRewriteModule.cs
@@ -76,7 +76,7 @@ namespace Forte.EpiserverRedirects.UrlRewritePlugin
         private string GetContentUrl(ContentReference contentReference, string language, bool validateTemplate = true)
         {
             var arguments = new VirtualPathArguments {ValidateTemplate = validateTemplate};
-            return UrlResolver.Service.GetUrl(contentReference, language, arguments);
+            return UrlResolver.Service.GetVirtualPath(contentReference, language, arguments)?.VirtualPath;
         }
 
         public void Uninitialize(InitializationEngine context)


### PR DESCRIPTION
Fixes old url generation. It should be relative url. GetUrl returns absolute or relative depending on if the contentLink is on current site and current request matches host that matches content and language.

GetUrl: https://world.episerver.com/documentation/class-library/?documentId=cms/11/26E0301B
GetVirtualPath: https://world.episerver.com/documentation/class-library/?documentId=cms/11/F00C9DA4

